### PR TITLE
Behaviour more alike to `dotenv` & support for complex objects

### DIFF
--- a/.env.json
+++ b/.env.json
@@ -1,3 +1,6 @@
 {
-  "sample": "value1"
+  "sample": "value1",
+  "complex": {
+    "foo": 1234
+  }
 }

--- a/index.js
+++ b/index.js
@@ -2,9 +2,14 @@ const {readFileSync} = require("fs");
 const {resolve} = require("path");
 
 
-module.exports = function dotenvJSON({encoding = 'utf8', path} = {}) {
-  if(!path) path = resolve(process.cwd(), '.env.json');
-
+module.exports = function dotenvJSON({encoding = 'utf8', env, dir, path} = {}) {
+  let dirpath = process.cwd();
+  let filename = '.env.json';
+  
+  if (env)    filename  = env === 'development' ? filename : `.env.${env}.json`;
+  if (dir)    dirpath   = resolve(dirpath, dir);
+  if (!path)  path      = resolve(dirpath, filename);
+  
   try {
     const parsed = JSON.parse(readFileSync(path, {encoding}));
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ module.exports = function dotenvJSON({encoding = 'utf8', path} = {}) {
     const {env} = process
     for (const key in parsed) {
       if (!env.hasOwnProperty(key)) {
-        env[key] = parsed[key];
+        const value = parsed[key];
+
+        env[key] = typeof value === 'string' ? value : JSON.stringify(value);
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -1,20 +1,22 @@
-const path = require("path");
-const fs = require("fs");
+const {readFileSync} = require("fs");
+const {resolve} = require("path");
 
-module.exports = function dotenvJSON(options) {
-  const jsonFile = (options && options.path) || ".env.json";
 
-  const jsonString = fs.readFileSync(path.resolve(process.cwd(), jsonFile), {
-    encoding: "utf8"
-  });
+module.exports = function dotenvJSON({encoding = 'utf8', path} = {}) {
+  if(!path) path = resolve(process.cwd(), '.env.json');
 
   try {
-    const envConfig = JSON.parse(jsonString);
+    const parsed = JSON.parse(readFileSync(path, {encoding}));
 
-    for (const key in envConfig) {
-      process.env[key] = process.env[key] || envConfig[key];
+    const {env} = process
+    for (const key in parsed) {
+      if (!env.hasOwnProperty(key)) {
+        env[key] = parsed[key];
+      }
     }
-  } catch (err) {
-    console.error(err);
+
+    return {parsed};
+  } catch (error) {
+    return {error};
   }
 };

--- a/index.test.js
+++ b/index.test.js
@@ -3,8 +3,12 @@ const assert = require("assert");
 const dotenvJSON = require("./index");
 
 assert.ok(!process.env.hasOwnProperty("sample"));
+assert.ok(!process.env.hasOwnProperty("complex"));
 
 dotenvJSON(); // loads .env.json
 
 assert.ok(process.env.hasOwnProperty("sample"));
 assert.equal(process.env.sample, "value1");
+
+assert.ok(process.env.hasOwnProperty("complex"));
+assert.equal(process.env.complex, '{"foo":1234}');

--- a/index.test.js
+++ b/index.test.js
@@ -1,14 +1,3 @@
-const assert = require("assert");
-
-const dotenvJSON = require("./index");
-
-assert.ok(!process.env.hasOwnProperty("sample"));
-assert.ok(!process.env.hasOwnProperty("complex"));
-
-dotenvJSON(); // loads .env.json
-
-assert.ok(process.env.hasOwnProperty("sample"));
-assert.equal(process.env.sample, "value1");
-
-assert.ok(process.env.hasOwnProperty("complex"));
-assert.equal(process.env.complex, '{"foo":1234}');
+require('./test/complex.test');
+require('./test/dir.test');
+require('./test/environment.test');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotenv-json",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Load environment variables via a JSON file",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/maxbeatty/dotenv-json.git"
   },
   "keywords": [
-    "dotenv"
+    "dotenv", "dotenv-json"
   ],
   "author": "Max Beatty",
   "license": "MIT",

--- a/test/.env.json
+++ b/test/.env.json
@@ -1,0 +1,3 @@
+{
+  "changed_directory": "test_directory"
+}

--- a/test/.env.production.json
+++ b/test/.env.production.json
@@ -1,0 +1,3 @@
+{
+  "current_filename": ".env.production.json"
+}

--- a/test/complex.test.js
+++ b/test/complex.test.js
@@ -1,0 +1,14 @@
+const assert = require("assert");
+
+const dotenvJSON = require("../index");
+
+assert.ok(!process.env.hasOwnProperty("sample"));
+assert.ok(!process.env.hasOwnProperty("complex"));
+
+dotenvJSON(); // loads .env.json
+
+assert.ok(process.env.hasOwnProperty("sample"));
+assert.equal(process.env.sample, "value1");
+
+assert.ok(process.env.hasOwnProperty("complex"));
+assert.equal(process.env.complex, '{"foo":1234}');

--- a/test/dir.test.js
+++ b/test/dir.test.js
@@ -1,0 +1,10 @@
+const assert = require("assert");
+
+const dotenvJSON = require("../index");
+
+assert.ok(!process.env.hasOwnProperty("changed_directory"));
+
+dotenvJSON({dir: 'test'}); // loads test/.env.json
+
+assert.ok(process.env.hasOwnProperty("changed_directory"));
+assert.equal(process.env.changed_directory, "test_directory");

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -1,0 +1,10 @@
+const assert = require("assert");
+
+const dotenvJSON = require("../index");
+
+assert.ok(!process.env.hasOwnProperty("current_filename"));
+
+dotenvJSON({dir: 'test', env: 'production'}); // loads test/.env.production.json
+
+assert.ok(process.env.hasOwnProperty("current_filename"));
+assert.equal(process.env.current_filename, '.env.production.json');


### PR DESCRIPTION
This pull-request offer a behaviour and API similtar to the one of `dotenv` module so they can be interchangeable, and also add support of complex objects (anything other than strings) by using `JSON-stringify()` to allow to store them in `process.env` object.